### PR TITLE
Update formatter.js on commnetPermlink

### DIFF
--- a/src/formatter.js
+++ b/src/formatter.js
@@ -184,6 +184,12 @@ module.exports = steemAPI => {
         .replace(/[^a-zA-Z0-9]+/g, "")
         .toLowerCase();
       parentPermlink = parentPermlink.replace(/(-\d{8}t\d{9}z)/g, "");
+      
+      var dotCheck = ".";
+      if(parentAuthor.indexOf(dotCheck) != -1){		
+		    var parentAuthor = parentAuthor.replace(".","dot");
+      }
+      
       return "re-" + parentAuthor + "-" + parentPermlink + "-" + timeStr;
     },
 


### PR DESCRIPTION
If steemit id includes ".", then this causes assertfail wth code 10 in broadcast.comment for reply.
So this code replace "." to "dot". It is true that programmer can make workaround for this. However to find this is very hard job for their debug. 

Also I have never seen any id with more than one ".". So I do not sue /g option for replace.

So I propose this fix on commentPermlink.